### PR TITLE
Fix bug in RandDropout

### DIFF
--- a/lib/transforms.py
+++ b/lib/transforms.py
@@ -140,7 +140,7 @@ class HueSaturationTranslation(object):
 ##############################
 class RandomDropout(object):
 
-  def __init__(self, dropout_ratio=0.2, dropout_application_ratio=0.5):
+  def __init__(self, dropout_ratio=0.2, dropout_application_ratio=0.2):
     """
     upright_axis: axis index among x,y,z, i.e. 2 for z
     """
@@ -148,7 +148,7 @@ class RandomDropout(object):
     self.dropout_application_ratio = dropout_application_ratio
 
   def __call__(self, coords, feats, labels):
-    if random.random() < self.dropout_ratio:
+    if random.random() < self.dropout_application_ratio:
       N = len(coords)
       inds = np.random.choice(N, int(N * (1 - self.dropout_ratio)), replace=False)
       return coords[inds], feats[inds], labels[inds]


### PR DESCRIPTION
Hi, Chrischoy. Thanks for your excellent work, and I benefit greatly from your work. I noticed that RandDropout has an unused parameter called **dropout_application_ratio**. I presumed it should control whether apply RandDropout and made the following change. To prevent this modify influencing performance, I change the default value of **dropout_application_ratio** to **dropout_ratio**.